### PR TITLE
Fix wrong attribution in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2022 Frederik Goovaerts <FrederikGoovaerts>
-Copyright (c) 2016-2022 Matt Phillips <mattphillips>
+Copyright (c) 2022-present Frederik Goovaerts <FrederikGoovaerts>
+Copyright (c) 2016-present Matt Phillips <mattphillips>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR fixes a wrong statement in the LICENSE file that the copyright of the inspiring author only applied until this year, which is incorrect.