### PR TITLE
Remove Node.js 12 from test environments in favor of Node.js 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As Node.js 12 has reached EOL a couple of months ago, we remove it from the test environments of Github actions. We introduce Node.js 18 as a new environment instead.

This does not mean the library is not supported on this environment anymore, as the code is still transpiled to ES2016. It implies that development environments for this library should have an up-to-date Node.js version.